### PR TITLE
Feat/1 root layout setup

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: false,
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@font-face {
+  font-family: "Pretendard";
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Pretendard";
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff")
+    format("woff");
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Pretendard";
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff")
+    format("woff");
+  font-weight: 600;
+  font-style: normal;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <body>{children}</body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" className="font-pretendard antialiased">
       <body>{children}</body>
     </html>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,14 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        pretendard: ["Pretendard", "sans-serif"],
+      },
+      fontWeight: {
+        normal: "400",
+        medium: "500",
+        semibold: "600",
+      },
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",


### PR DESCRIPTION
## ✅ 푸시 전에 빌드했나요?
- [x] 네


## 🔑 Key changes
- 글로벌 CSS 설정
  - globals.css에 Pretendard 폰트 임포트
  - tailwind fontFamily와 fontWeight 설정
  - RootLayout 한국어로 변경하고 전역으로 Pretendard 폰트 지정


## 🧑🏻‍💻 To reviewer
- 기본 폰트를 Pretendard로, 폰트 굵기를 normal로 설정해 두었습니다.
- 우선적으로 설정한 폰트는 Pretendard 하나이며 폰트는 normal, medium, semibold를 갖습니다.
