### PR TITLE
Feat/13 add body component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Main from "@/components/Main";
+import StartGuide from "@/components/StartGuide";
 
 export const metadata: Metadata = {
   title: "Criends",
@@ -18,6 +19,7 @@ export default function RootLayout({
     <html lang="ko" className="font-pretendard antialiased">
       <body className="flex flex-col min-h-screen">
         <Header />
+        <StartGuide />
         <Main>{children}</Main>
         <Footer />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,8 @@
 import Section from "@/components/Section";
-import StartGuide from "@/components/StartGuide";
 
 export default function Home() {
   return (
     <div>
-      <StartGuide />
-
       {/* 이력서 안내 섹션 */}
       <Section
         title="눈에 띄는 이력서를 준비해보세요."

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ export default function Header() {
 
         <Link
           href="/login"
-          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all"
+          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
         >
           <User size={20} />
           <span>Login</span>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -9,7 +9,7 @@ export default function Main({
   heading,
 }: PropsWithChildren<MainProps>) {
   return (
-    <main className="min-h-screen pt-[5rem] py-5">
+    <main className="min-h-screen mx-52 bg-slate-300">
       <h1>{heading}</h1>
       {children}
     </main>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -9,7 +9,7 @@ export default function Main({
   heading,
 }: PropsWithChildren<MainProps>) {
   return (
-    <main className="min-h-screen mx-52 bg-slate-300">
+    <main className="min-h-screen py-5 mx-4 md:mx-40">
       <h1>{heading}</h1>
       {children}
     </main>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -18,43 +18,41 @@ export default function Section({
 }: SectionProps) {
   return (
     <section className="w-full py-14 my-14 flex justify-center">
-      <div className="w-full">
-        <div
-          className={clsx("flex flex-col md:flex-row gap-10 my-auto", {
-            "md:flex-row-reverse": reverse,
-          })}
-        >
-          <div className="w-full md:w-1/2 bg-slate-200">
-            <div className="aspect-w-16 aspect-h-9 bg-slate-400 rounded-lg h-[400px]"></div>
+      <div
+        className={clsx("w-full flex flex-col md:flex-row gap-10 my-auto", {
+          "md:flex-row-reverse": reverse,
+        })}
+      >
+        <div className="w-full md:w-1/2 bg-slate-200">
+          <div className="aspect-w-16 aspect-h-9 bg-slate-400 rounded-lg h-[400px]"></div>
+        </div>
+        <div className="w-full h-full md:w-1/2 flex flex-col justify-between md:h-[400px]">
+          <div className="flex flex-col gap-5 h-full">
+            <h2 className="text-2xl font-semibold">{title}</h2>
+            <div className="overflow-y-auto pr-2 max-h-[200px] md:max-h-none">
+              <p className="text-base">{description}</p>
+            </div>
           </div>
-          <div className="w-full h-full md:w-1/2 flex flex-col justify-between md:h-[400px]">
-            <div className="flex flex-col gap-5 h-full">
-              <h2 className="text-2xl font-semibold">{title}</h2>
-              <div className="overflow-y-auto pr-2 max-h-[200px] md:max-h-none">
-                <p className="text-base">{description}</p>
-              </div>
-            </div>
-            <div
-              className={clsx(
-                `mt-5 flex gap-5 justify-center md:justify-end text-sm`,
-                {
-                  "md:justify-end": reverse,
-                }
-              )}
+          <div
+            className={clsx(
+              `mt-5 flex gap-5 justify-center md:justify-end text-sm`,
+              {
+                "md:justify-end": reverse,
+              }
+            )}
+          >
+            <Link
+              href={link1.href}
+              className="px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all"
             >
-              <Link
-                href={link1.href}
-                className="px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all"
-              >
-                {link1.label}
-              </Link>
-              <Link
-                href={link2.href}
-                className="px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all"
-              >
-                {link2.label}
-              </Link>
-            </div>
+              {link1.label}
+            </Link>
+            <Link
+              href={link2.href}
+              className="px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all"
+            >
+              {link2.label}
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -17,15 +17,15 @@ export default function Section({
   link2,
 }: SectionProps) {
   return (
-    <section className="w-full py-10 flex justify-center">
-      <div className="w-full max-w-7xl px-4 sm:px-6 md:px-8">
+    <section className="w-full py-14 my-14 flex justify-center">
+      <div className="w-full">
         <div
           className={clsx("flex flex-col md:flex-row gap-10 my-auto", {
             "md:flex-row-reverse": reverse,
           })}
         >
           <div className="w-full md:w-1/2 bg-slate-200">
-            <div className="aspect-w-16 aspect-h-9 bg-slate-200 rounded-lg h-[400px]"></div>
+            <div className="aspect-w-16 aspect-h-9 bg-slate-400 rounded-lg h-[400px]"></div>
           </div>
           <div className="w-full h-full md:w-1/2 flex flex-col justify-between md:h-[400px]">
             <div className="flex flex-col gap-5 h-full">
@@ -36,7 +36,7 @@ export default function Section({
             </div>
             <div
               className={clsx(
-                `mt-5 flex gap-5 justify-center md:justify-start text-sm`,
+                `mt-5 flex gap-5 justify-center md:justify-end text-sm`,
                 {
                   "md:justify-end": reverse,
                 }

--- a/src/components/StartGuide.tsx
+++ b/src/components/StartGuide.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function StartGuide() {
   return (
-    <div className="px-10 md:px-0 py-44 flex flex-col text-center bg-slate-300 relative">
+    <div className="mt-[5rem] px-10 md:px-0 py-44 flex flex-col text-center bg-slate-300 relative">
       <div className="absolute inset-0 flex justify-center items-center">
         <div className="w-[450px] h-[450px] bg-brand rounded-full opacity-50 blur-3xl"></div>
         {/* <div className="w-0 h-0 border-brand border-x-[600px] border-t-[600px] border-transparent border-t-brand opacity-50 blur-3xl"></div> */}


### PR DESCRIPTION
## ✅ 푸시 전에 빌드했나요?
- [x] 네


## 🔑 Key changes 
- Main 컴포넌트 수정
  - Header와 Footer 사이의 Body 역할을 위해 mx 값을 추가했습니다
  - 반응형 디자인
- Layout 구성 수정
  - StartGuide를 Main밖으로 뺐습니다.
  - StartGuide 자체에 mt 값 넣었습니다.
- Section 컴포넌트 수정
  - Section에 padding, margin 수정했습니다!
- login 버튼 수정
  - icon 세로 방향 센터 정렬했습니다


## 🧑🏻‍💻 To reviewer
- Main을 반응형으로 만들긴 했는데 margin값 맘에 안들면 바꾸셔도 됩니다!!!
