### PR TITLE
Feat/20 login feature

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  env: {
+    PORT: process.env.PORT || 3001,
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "class-variance-authority": "^0.7.0",
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
@@ -962,6 +963,12 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -984,6 +991,17 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1215,6 +1233,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1411,6 +1441,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/didyoumean": {
@@ -2201,6 +2240,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2224,6 +2283,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -3234,6 +3307,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3858,6 +3952,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const apiClient = axios.create({
+  baseURL: "http://localhost:3000",
+  withCredentials: true,
+});

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,0 +1,4 @@
+import { apiClient } from "./apiClient";
+
+export const loginApi = (email: string, password: string) =>
+  apiClient.post("/auth/login", { email, password });

--- a/src/api/check.api.ts
+++ b/src/api/check.api.ts
@@ -1,0 +1,3 @@
+import { apiClient } from "./apiClient";
+
+export const helloWorldApi = () => apiClient.get("/");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import Main from "@/components/Main";
 import StartGuide from "@/components/StartGuide";
+import AuthContextProvider from "@/contexts/auth.context";
 
 export const metadata: Metadata = {
   title: "Criends",
@@ -20,7 +21,9 @@ export default function RootLayout({
       <body className="flex flex-col min-h-screen">
         <Header />
         <StartGuide />
-        <Main>{children}</Main>
+        <AuthContextProvider>
+          <Main>{children}</Main>
+        </AuthContextProvider>
         <Footer />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import AuthContextProvider from "@/contexts/auth.context";
 
 export const metadata: Metadata = {
   title: "Criends",
@@ -16,9 +17,11 @@ export default function RootLayout({
   return (
     <html lang="ko" className="font-pretendard antialiased">
       <body className="flex flex-col min-h-screen">
-        <Header />
-        {children}
-        <Footer />
+        <AuthContextProvider>
+          <Header />
+          {children}
+          <Footer />
+        </AuthContextProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,12 +19,12 @@ export default function RootLayout({
   return (
     <html lang="ko" className="font-pretendard antialiased">
       <body className="flex flex-col min-h-screen">
-        <Header />
-        <StartGuide />
         <AuthContextProvider>
+          <Header />
+          <StartGuide />
           <Main>{children}</Main>
+          <Footer />
         </AuthContextProvider>
-        <Footer />
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import SocialLoginContainer from "@/components/SocialLoginContainer";
 export default function page() {
   return (
     <Main>
-      <section className="w-80 mx-auto mt-52">
+      <section className="w-80 mx-auto mt-40">
         <LoginForm />
 
         <div className="flex justify-center items-center my-5">

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useAuth } from "@/contexts/auth.context";
+import Link from "next/link";
+import { User } from "react-feather";
+
+export default function AuthButtons() {
+  const { isAuthenticated, logout } = useAuth();
+
+  return (
+    <>
+      {!isAuthenticated ? (
+        <Link
+          href="/login"
+          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+        >
+          <User size={20} />
+          <span>Login</span>
+        </Link>
+      ) : (
+        <button
+          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+          onClick={logout}
+        >
+          <User size={20} />
+          <span>Logout</span>
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,29 +1,45 @@
 "use client";
 
-import { useAuth } from "@/contexts/auth.context";
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useAuth } from "@/contexts/auth.context";
 import { User } from "react-feather";
 
 export default function AuthButtons() {
   const { isAuthenticated, logout } = useAuth();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted)
+    return (
+      <div className="flex gap-3 px-[0.65rem] py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center duration-300 ease-in-out overflow-hidden w-10 hover:w-24 animate-pulse">
+        <User size={20} className="flex-shrink-0" />
+        <span>Check</span>
+      </div>
+    );
 
   return (
     <>
       {!isAuthenticated ? (
         <Link
           href="/login"
-          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+          // 이전 버전: className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+          className="flex gap-3 px-[0.65rem] py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center duration-300 ease-in-out overflow-hidden w-10 hover:w-24"
         >
-          <User size={20} />
-          <span>Login</span>
+          <User size={20} className="flex-shrink-0" />
+          <span className="whitespace-nowrap">Login</span>
         </Link>
       ) : (
         <button
-          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+          // 이전 버전: className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
+          className="flex gap-3 px-[0.65rem] py-2 bg-brand text-white hover:bg-red-500 hover:text-white rounded-full transition-all items-center duration-300 ease-in-out overflow-hidden w-10 hover:w-[6.5rem]"
           onClick={logout}
         >
-          <User size={20} />
-          <span>Logout</span>
+          <User size={20} className="flex-shrink-0" />
+          <span className="whitespace-nowrap">Logout</span>
         </button>
       )}
     </>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import NavLinks from "./NavLinks";
-import { User } from "react-feather";
+import AuthButtons from "./AuthButtons";
 
 export default function Header() {
   return (
@@ -18,14 +18,7 @@ export default function Header() {
             <NavLinks />
           </nav>
         </div>
-
-        <Link
-          href="/login"
-          className="flex gap-2 px-4 py-2 bg-brand text-white hover:bg-slate-200 hover:text-brand rounded-full transition-all items-center"
-        >
-          <User size={20} />
-          <span>Login</span>
-        </Link>
+        <AuthButtons />
       </div>
     </header>
   );

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useAuth } from "@/contexts/auth.context";
 import { redirect } from "next/navigation";
+import { LoginData, useAuth } from "@/contexts/auth.context";
+import { ChangeEvent, useEffect, useState } from "react";
+import clsx from "clsx";
 
 export default function LoginForm() {
   const { login } = useAuth();
+  const [{ email, password }, setEnteredValue] = useState<LoginData>({
+    email: "",
+    password: "",
+  });
+  const [dynamicErrorMsg, setDynamicErrorMsg] = useState<string | null>(null);
 
   async function handleSubmit(formData: FormData) {
+    // setEnteredValue({ email: "", password: "" }); // 선택
+    setDynamicErrorMsg(null);
+
     const data = {
       email: formData.get("email") as string,
       password: formData.get("password") as string,
@@ -14,25 +24,55 @@ export default function LoginForm() {
 
     if (await login(data)) {
       redirect("/");
+    } else {
+      setDynamicErrorMsg("아이디 또는 비밀번호를 확인해주세요.");
     }
   }
 
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    setEnteredValue((prevEnteredValue) => ({
+      ...prevEnteredValue,
+      [event.target.name]: event.target.value,
+    }));
+  }
+
+  useEffect(() => {
+    if (email || password) {
+      setDynamicErrorMsg(null);
+    }
+  }, [email, password]);
+
   return (
     <form className="flex flex-col gap-2" action={handleSubmit}>
+      <div className="w-full h-10">
+        {dynamicErrorMsg && (
+          <p className="text-center text-red-500 text-sm mb-2">
+            {dynamicErrorMsg}
+          </p>
+        )}
+      </div>
       <fieldset className="flex flex-col gap-2">
         <input
           type="email"
-          className="bg-[#eeeeee] px-4 py-2 rounded-full outline-none"
+          className={clsx(`bg-[#eeeeee] px-4 py-2 rounded-full outline-none`, {
+            "border border-red-500": dynamicErrorMsg,
+          })}
           name="email"
           placeholder="아이디를 입력하세요."
           required
+          value={email}
+          onChange={(event) => handleChange(event)}
         />
         <input
           type="password"
-          className="bg-[#eeeeee] px-4 py-2 rounded-full outline-none"
+          className={clsx(`bg-[#eeeeee] px-4 py-2 rounded-full outline-none`, {
+            "border border-red-500": dynamicErrorMsg,
+          })}
           name="password"
           placeholder="비밀번호를 입력하세요."
           required
+          value={password}
+          onChange={(event) => handleChange(event)}
         />
       </fieldset>
       <button className="bg-brand w-full px-2 py-2 rounded-full text-white">

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,14 +1,36 @@
+"use client";
+
+import { loginApi } from "@/api/auth.api";
+
 export default function LoginForm() {
+  async function login(formData: FormData) {
+    const email = String(formData.get("email"));
+    const password = String(formData.get("password"));
+
+    // 이메일 형식 검증
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      console.error("유효하지 않은 이메일 형식입니다.");
+      return;
+    }
+
+    await loginApi(email, password)
+      .then((response) => console.log(response.data))
+      .catch((error) => console.log(error));
+  }
+
   return (
-    <form className="flex flex-col gap-2">
+    <form className="flex flex-col gap-2" action={login}>
       <fieldset className="flex flex-col gap-2">
         <input
-          type="text"
+          type="email"
           className="bg-[#eeeeee] px-4 py-2 rounded-full outline-none"
+          name="email"
         />
         <input
           type="password"
           className="bg-[#eeeeee] px-4 py-2 rounded-full outline-none"
+          name="password"
         />
       </fieldset>
       <button className="bg-brand w-full px-2 py-2 rounded-full text-white">

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,26 +1,24 @@
 "use client";
 
-import { loginApi } from "@/api/auth.api";
+import { useAuth } from "@/contexts/auth.context";
+import { redirect } from "next/navigation";
 
 export default function LoginForm() {
-  async function login(formData: FormData) {
-    const email = String(formData.get("email"));
-    const password = String(formData.get("password"));
+  const { login } = useAuth();
 
-    // 이메일 형식 검증
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      console.error("유효하지 않은 이메일 형식입니다.");
-      return;
+  async function handleSubmit(formData: FormData) {
+    const data = {
+      email: formData.get("email") as string,
+      password: formData.get("password") as string,
+    };
+
+    if (await login(data)) {
+      redirect("/");
     }
-
-    await loginApi(email, password)
-      .then((response) => console.log(response.data))
-      .catch((error) => console.log(error));
   }
 
   return (
-    <form className="flex flex-col gap-2" action={login}>
+    <form className="flex flex-col gap-2" action={handleSubmit}>
       <fieldset className="flex flex-col gap-2">
         <input
           type="email"

--- a/src/contexts/auth.context.tsx
+++ b/src/contexts/auth.context.tsx
@@ -11,12 +11,14 @@ export type LoginData = {
 
 interface AuthContextType {
   isAuthenticated: boolean;
+  errorMessage: string | null;
   login: (data: LoginData) => Promise<boolean>;
   logout: () => void;
 }
 
 const initialAuthContext: AuthContextType = {
   isAuthenticated: false,
+  errorMessage: null,
   login: async () => false,
   logout: () => {},
 };
@@ -28,6 +30,7 @@ export default function AuthContextProvider({
 }: {
   children: React.ReactNode;
 }) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => {
     if (typeof window !== "undefined") {
       return !!sessionStorage.getItem("accessToken");
@@ -43,7 +46,7 @@ export default function AuthContextProvider({
 
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(email)) {
-        console.error("유효하지 않은 이메일 형식입니다.");
+        setErrorMessage("유효하지 않은 이메일 형식입니다.");
         return false;
       }
 
@@ -64,10 +67,12 @@ export default function AuthContextProvider({
         return true;
       } else {
         console.error("로그인 응답에 accessToken이 없습니다.");
+        setErrorMessage("이메일 또는 비밀번호를 확인해주세요.");
         return false;
       }
     } catch (error) {
       console.error("로그인 중 오류 발생:", error);
+      setErrorMessage("이메일 또는 비밀번호를 확인해주세요.");
       logout();
       return false;
     }
@@ -96,6 +101,7 @@ export default function AuthContextProvider({
 
   const value: AuthContextType = {
     isAuthenticated,
+    errorMessage,
     login,
     logout,
   };

--- a/src/contexts/auth.context.tsx
+++ b/src/contexts/auth.context.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { loginApi } from "@/api/auth.api";
+import { createContext, useContext, useState } from "react";
+
+export type LoginData = {
+  email: string;
+  password: string;
+};
+
+interface AuthContextType {
+  username: string | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (data: LoginData) => Promise<boolean>;
+  logout: () => void;
+}
+
+const initialAuthContext: AuthContextType = {
+  username: null,
+  token: null,
+  isAuthenticated: false,
+  login: async () => false,
+  logout: () => {},
+};
+
+export const AuthContext = createContext<AuthContextType>(initialAuthContext);
+
+export default function AuthContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [username, setUsername] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  async function login(data: LoginData): Promise<boolean> {
+    try {
+      const { email, password } = data;
+
+      if (!email || !password) return false;
+
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(email)) {
+        console.error("유효하지 않은 이메일 형식입니다.");
+        return false;
+      }
+
+      const response = await loginApi(email, password);
+
+      if (response.data && response.data.accessToken) {
+        setIsAuthenticated(true);
+        setUsername(email.split("@")[0]);
+        setToken(response.data.accessToken);
+        return true;
+      } else {
+        console.error("로그인 응답에 accessToken이 없습니다.");
+        return false;
+      }
+    } catch (error) {
+      console.error("로그인 중 오류 발생:", error);
+      logout();
+      return false;
+    }
+  }
+
+  function logout() {
+    setIsAuthenticated(false);
+    setUsername(null);
+    setToken(null);
+  }
+
+  const value: AuthContextType = {
+    username,
+    token,
+    isAuthenticated,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/contexts/auth.context.tsx
+++ b/src/contexts/auth.context.tsx
@@ -10,14 +10,12 @@ export type LoginData = {
 };
 
 interface AuthContextType {
-  username: string | null;
   isAuthenticated: boolean;
   login: (data: LoginData) => Promise<boolean>;
   logout: () => void;
 }
 
 const initialAuthContext: AuthContextType = {
-  username: null,
   isAuthenticated: false,
   login: async () => false,
   logout: () => {},
@@ -30,8 +28,12 @@ export default function AuthContextProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [username, setUsername] = useState<string | null>(null);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => {
+    if (typeof window !== "undefined") {
+      return !!sessionStorage.getItem("accessToken");
+    }
+    return false;
+  });
 
   async function login(data: LoginData): Promise<boolean> {
     try {
@@ -49,7 +51,6 @@ export default function AuthContextProvider({
 
       if (response.data && response.data.accessToken) {
         setIsAuthenticated(true);
-        setUsername(email.split("@")[0]);
 
         sessionStorage.setItem("accessToken", response.data.accessToken);
 
@@ -90,12 +91,10 @@ export default function AuthContextProvider({
 
   function logout() {
     setIsAuthenticated(false);
-    setUsername(null);
     sessionStorage.removeItem("accessToken");
   }
 
   const value: AuthContextType = {
-    username,
     isAuthenticated,
     login,
     logout,


### PR DESCRIPTION
## ✅ 푸시 전에 빌드했나요?
- [x] 네


## 🔑 Key changes
- 로그인 기능 구현
  - AuthContext 생성 및 구현
  - 이메일 로그인 구현
  - 로그인 유지 구현


## 🧑🏻‍💻 To reviewer
- 이메일 로그인은 Context를 활용했습니다.
- AuthContext에는 isAuthenticated, errorMessage, login, logout이 정의되어 있습니다.
- errorMessage는 로그인 오류들이 정확히 분류되면 로그인 폼 내부의 오류 메세지를 대신해 사용할 수 있습니다.
- refreshToken에 대한 논의가 부족해 로그인 유지는 sessionStorage를 사용했으나 추후에 refresh로 교체할 수 있습니다.
- 로그인 유지 중 로그인 후 새로고침으로 후 로그인 상태 확인 딜레이로 인해 로그인에서 로그아웃 버튼으로의 변화가 부자연스러움을 줄 것을 우려해 버튼 UI를 바꿨으나 원하는 대로 주석을 풀어 쉽게 변경할 수 있습니다.
- 프론트엔드 측 포트 변경 과정에서 환경 변수가 동작하지 않아 타이핑 해서 사용했으나 개발 로컬 포트 번호이므로 문제 없을 거라 판단, 포함시켰습니다.
